### PR TITLE
Add unit tests and bug fixes for Admin View Products pages

### DIFF
--- a/client/src/pages/admin/Products.js
+++ b/client/src/pages/admin/Products.js
@@ -11,10 +11,15 @@ const Products = () => {
   const getAllProducts = async () => {
     try {
       const { data } = await axios.get("/api/v1/product/get-product");
-      setProducts(data.products);
+
+      if (data?.success && Array.isArray(data.products)) {
+        setProducts(data.products);
+      } else {
+        toast.error(data?.message ?? "Something Went Wrong");
+      }
     } catch (error) {
       console.log(error);
-      toast.error("Someething Went Wrong");
+      toast.error("Something Went Wrong");
     }
   };
 
@@ -22,6 +27,7 @@ const Products = () => {
   useEffect(() => {
     getAllProducts();
   }, []);
+
   return (
     <Layout>
       <div className="row">
@@ -30,9 +36,14 @@ const Products = () => {
         </div>
         <div className="col-md-9 ">
           <h1 className="text-center">All Products List</h1>
+          {/* Note: fixed overflow here previously in another PR */}
           <div className="row g-3">
             {products?.map((p) => (
-              <div key={p._id} className="col-12 col-sm-6 col-md-4">
+              <div
+                key={p._id}
+                className="col-12 col-sm-6 col-md-4"
+                data-testid="product-card"
+              >
                 <Link
                   to={`/dashboard/admin/product/${p.slug}`}
                   className="product-link"

--- a/client/src/pages/admin/Products.test.js
+++ b/client/src/pages/admin/Products.test.js
@@ -1,0 +1,119 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Products from "./Products";
+import axios from "axios";
+import toast from "react-hot-toast";
+import { SAMPLE_PRODUCTS } from "./testUtils/mockData";
+
+// Mock dependencies
+jest.mock("axios", () => ({
+  get: jest.fn(() => Promise.resolve({ data: {} })),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("../../components/Layout", () => ({
+  __esModule: true,
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+jest.mock("../../components/AdminMenu", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const renderComponentWithRouter = (component) =>
+  render(<MemoryRouter>{component}</MemoryRouter>);
+
+describe("Admin View Products", () => {
+  // Set-up / Clean-up state
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axios.get.mockResolvedValue({
+      data: { success: true, products: SAMPLE_PRODUCTS },
+    });
+  });
+
+  // Technique: Equivalence Partitioning — validates the typical success scenario where API returns a set of products, ensuring rendering logic works for the partition of valid results.
+  it("fetches products and renders a responsive card grid when API succeeds", async () => {
+    // Arrange + Act
+    renderComponentWithRouter(<Products />);
+
+    // Assert
+    await waitFor(() =>
+      expect(axios.get).toHaveBeenCalledWith("/api/v1/product/get-product")
+    );
+
+    const renderedCards = await screen.findAllByTestId("product-card");
+    expect(renderedCards).toHaveLength(SAMPLE_PRODUCTS.length);
+
+    for (const product of SAMPLE_PRODUCTS) {
+      expect(screen.getByText(product.name)).toBeInTheDocument();
+      expect(screen.getByText(product.description)).toBeInTheDocument();
+      const image = screen.getByAltText(product.name);
+      expect(image).toHaveAttribute(
+        "src",
+        `/api/v1/product/product-photo/${product._id}`
+      );
+    }
+  });
+
+  // Technique: Control Flow Testing — forces the error branch within getAllProducts to execute, asserting toast notification coverage when the HTTP request throws.
+  it("shows a toast error when the product fetch fails", async () => {
+    // Arrange
+    const error = new Error("network unreachable");
+    axios.get.mockRejectedValueOnce(error);
+
+    // Act
+    renderComponentWithRouter(<Products />);
+
+    // Assert
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Someething Went Wrong")
+    );
+  });
+
+  // Technique: Boundary Value Analysis — evaluates the lower boundary of zero products to ensure the grid gracefully renders without cards or stray links when the dataset is empty.
+  it("renders an empty grid with no product links when API returns zero products", async () => {
+    // Arrange - stubs return stub data
+    axios.get.mockResolvedValueOnce({
+      data: { success: true, products: [] },
+    });
+
+    // Act
+    renderComponentWithRouter(<Products />);
+
+    // Assert
+    await waitFor(() =>
+      expect(axios.get).toHaveBeenCalledWith("/api/v1/product/get-product")
+    );
+
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+
+  it("maps each product card link to the correct update product page", async () => {
+    // Arrange + Act
+    renderComponentWithRouter(<Products />);
+
+    // Assert
+    const renderedLinks = await screen.findAllByRole("link");
+    expect(renderedLinks).toHaveLength(SAMPLE_PRODUCTS.length);
+
+    for (const product of SAMPLE_PRODUCTS) {
+      const link = screen.getByRole("link", {
+        name: new RegExp(product.name, "i"),
+      });
+      expect(link).toHaveAttribute(
+        "href",
+        `/dashboard/admin/product/${product.slug}`
+      );
+    }
+  });
+});

--- a/client/src/pages/admin/Products.test.js
+++ b/client/src/pages/admin/Products.test.js
@@ -34,11 +34,21 @@ const renderComponentWithRouter = (component) =>
 
 describe("Admin View Products", () => {
   // Set-up / Clean-up state
+  beforeAll(() => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     axios.get.mockResolvedValue({
       data: { success: true, products: SAMPLE_PRODUCTS },
     });
+  });
+
+  afterAll(() => {
+    console.log.mockRestore();
+    console.error.mockRestore();
   });
 
   // Technique: Equivalence Partitioning — validates the typical success scenario where API returns a set of products, ensuring rendering logic works for the partition of valid results.
@@ -76,7 +86,7 @@ describe("Admin View Products", () => {
 
     // Assert
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith("Someething Went Wrong")
+      expect(toast.error).toHaveBeenCalledWith("Something Went Wrong")
     );
   });
 

--- a/client/src/pages/admin/testUtils/mockData.js
+++ b/client/src/pages/admin/testUtils/mockData.js
@@ -109,3 +109,37 @@ export const SAMPLE_ORDERS = [
     ],
   },
 ];
+export const SAMPLE_PRODUCTS = [
+  {
+    _id: "pid1",
+    name: "Ipad Protector",
+    slug: "ipad-protector",
+    description: "Screen protection for iPads.",
+    price: 12.99,
+    category: {
+      _id: "stationery",
+      name: "Stationery",
+      slug: "stationery",
+    },
+    quantity: 150,
+    shipping: true,
+    createdAt: "2025-02-01T09:00:00.000Z",
+    updatedAt: "2025-02-01T09:00:00.000Z",
+  },
+  {
+    _id: "pid2",
+    name: "Aurora Lamp",
+    slug: "aurora-lamp",
+    description: "Serene lighting with adaptive colors.",
+    price: 59.5,
+    category: {
+      _id: "lighting",
+      name: "Lighting",
+      slug: "lighting",
+    },
+    quantity: 80,
+    shipping: true,
+    createdAt: "2025-02-02T12:30:00.000Z",
+    updatedAt: "2025-02-02T12:30:00.000Z",
+  },
+];

--- a/jest.frontend.config.js
+++ b/jest.frontend.config.js
@@ -52,7 +52,8 @@ module.exports = {
     "<rootDir>/client/src/components/Form/CategoryForm.js",
     "<rootDir>/client/src/pages/admin/CreateProduct.js",
     "<rootDir>/client/src/pages/admin/UpdateProduct.js",
-    "<rootDir>/client/src/pages/admin/AdminOrders.test.js",
+    "<rootDir>/client/src/pages/admin/AdminOrders.js",
+    "<rootDir>/client/src/pages/admin/Products.js",
   ],
   coverageThreshold: {
     // Temporary lower the coverage thresholds form 100 to 90 to allow for CI to pass


### PR DESCRIPTION
## Summary of test cases added
> ### **Test Generation Techniques used**: Control Flow Testing, Equivalence Partitions, Boundary Value Analysis
### [frontend] client/src/pages/admin/Products.test.js

✓ fetches products and renders a responsive card grid when API succeeds (25 ms)
✓ shows a toast error when the product fetch fails (53 ms)
✓ renders an empty grid with no product links when API returns zero products (2 ms)
✓ maps each product card link to the correct update product page (47 ms)

> 🐞 (bug): Products display overflow over the right viewport edge of the page.
> <img width="568" height="398" alt="image" src="https://github.com/user-attachments/assets/40da4b55-99dc-4e6e-94d7-c3fb8f353ad5" />
> 🔧 (fix): Changed the display layout to a grid of 3 product cards per row.
> <img width="672" height="619" alt="image" src="https://github.com/user-attachments/assets/27182dc1-42e9-4373-81c9-f6a5fd67894a" />

#### Other improvementts
- Improved error handling for product fetching, such that if `data?.success` is `undefined`, then a `toast.error` would be shown, which is ubiquitous in the codebase.