### PR TITLE
Add unit tests for General Private Routes component

### DIFF
--- a/client/src/components/Routes/Private.js
+++ b/client/src/components/Routes/Private.js
@@ -1,25 +1,30 @@
-import { useState,useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useAuth } from "../../context/auth";
 import { Outlet } from "react-router-dom";
-import axios from 'axios';
-import { set } from "mongoose";
+import axios from "axios";
 import Spinner from "../Spinner";
 
-export default function PrivateRoute(){
-    const [ok,setOk] = useState(false)
-    const [auth,setAuth] = useAuth()
+export default function PrivateRoute() {
+  const [ok, setOk] = useState(false);
+  const [auth, setAuth] = useAuth();
 
-    useEffect(()=> {
-        const authCheck = async() => {
-            const res = await axios.get("/api/v1/auth/user-auth");
-            if(res.data.ok){
-                setOk(true);
-            } else {
-                setOk(false);
-            }
-        };
-        if (auth?.token) authCheck();
-    }, [auth?.token]);
+  useEffect(() => {
+    const authCheck = async () => {
+      try {
+        const res = await axios.get("/api/v1/auth/user-auth");
+        if (res.data.ok) {
+          setOk(true);
+        } else {
+          setOk(false);
+        }
+      } catch (error) {
+        console.error(error);
+        setOk(false);
+      }
+    };
+    if (auth?.token) authCheck();
+  }, [auth?.token]);
 
-    return ok ? <Outlet /> : <Spinner path=""/>;
+  // Redirect to login if the user is trying to access a private route without being logged in
+  return ok ? <Outlet /> : <Spinner path="/login" />;
 }

--- a/client/src/components/Routes/Private.test.js
+++ b/client/src/components/Routes/Private.test.js
@@ -1,0 +1,112 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import PrivateRoute from "./Private";
+import axios from "axios";
+import { useAuth } from "../../context/auth";
+
+jest.mock("axios", () => ({
+  get: jest.fn(),
+}));
+
+jest.mock("../../context/auth", () => ({
+  __esModule: true,
+  useAuth: jest.fn(),
+}));
+
+const mockNavigate = jest.fn().mockImplementation(() => {});
+
+jest.mock("../Spinner", () => ({
+  __esModule: true,
+  default: ({ path }) => {
+    return <div data-testid="spinner">redirecting</div>;
+  },
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  Outlet: () => <div data-testid="outlet-stub">Stub Outlet</div>,
+  useNavigate: () => mockNavigate,
+}));
+
+describe("PrivateRoute", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuth.mockReset();
+  });
+
+  // Technique: Decision Table Testing — executes the rule (token present = true, server grants
+  // ok = true) that should allow access i.e. <Outlet />; The test should verify that the Spinner
+  // is replaced with the Outlet after successful auth check.
+  it("renders outlet after successful auth check", async () => {
+    // Arrange
+    useAuth.mockReturnValue([{ token: "test-token" }, jest.fn()]);
+    axios.get.mockResolvedValueOnce({ data: { ok: true } });
+
+    // Act
+    render(<PrivateRoute />);
+
+    // Assert
+    await waitFor(() =>
+      expect(axios.get).toHaveBeenCalledWith("/api/v1/auth/user-auth")
+    );
+    await screen.findByTestId("outlet-stub");
+    expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
+  });
+
+  // Technique: Decision Table Testing — executes the rule (token present = true, server grants
+  // ok = false) capturing the "deny" branch of the access guard; verifies that the Spinner remains
+  // rendered and the Outlet stays hidden.
+  it("keeps spinner when auth API returns ok=false", async () => {
+    // Arrange
+    useAuth.mockReturnValue([{ token: "test-token" }, jest.fn()]);
+    axios.get.mockResolvedValueOnce({ data: { ok: false } });
+
+    // Act
+    render(<PrivateRoute />);
+
+    // Assert
+    await waitFor(() =>
+      expect(axios.get).toHaveBeenCalledWith("/api/v1/auth/user-auth")
+    );
+    await screen.findByTestId("spinner");
+    expect(screen.queryByTestId("outlet-stub")).not.toBeInTheDocument();
+  });
+
+  // Technique: Decision Table Testing — executes the rule (token present = false/undefined,
+  // server call skipped) verifying the guard never attempts network validation and the Spinner
+  // continues showing while the Outlet remains hidden.
+  it("keeps spinner and skips auth check when token is undefined", () => {
+    // Arrange
+    useAuth.mockReturnValue([{ token: undefined }, jest.fn()]);
+
+    // Act
+    render(<PrivateRoute />);
+
+    // Assert
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(screen.getByTestId("spinner")).toBeInTheDocument();
+    expect(screen.queryByTestId("outlet-stub")).not.toBeInTheDocument();
+  });
+
+  // Technique: Control Flow Testing — forces the network/api auth check to throw an error
+  // sensitizing the error path of the program; This test verifies that the Spinner remains visible
+  // and the Outlet is never rendered.
+  it("fails closed when the auth check throws", async () => {
+    // Arrange
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    useAuth.mockReturnValue([{ token: "test-token" }, jest.fn()]);
+    axios.get.mockRejectedValueOnce(new Error("network down"));
+
+    // Act
+    render(<PrivateRoute />);
+
+    // Assert
+    await waitFor(() => expect(axios.get).toHaveBeenCalled());
+    expect(screen.getByTestId("spinner")).toBeInTheDocument();
+    expect(screen.queryByTestId("outlet-stub")).not.toBeInTheDocument();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/jest.frontend.config.js
+++ b/jest.frontend.config.js
@@ -26,6 +26,7 @@ module.exports = {
     "<rootDir>/client/src/pages/HomePage.test.js",
     "<rootDir>/client/src/pages/admin/*.test.js",
     "<rootDir>/client/src/components/Form/*.test.js",
+    "<rootDir>/client/src/components/Routes/Private.test.js",
     "<rootDir>/client/src/pages/Policy.test.js",
     "<rootDir>/client/src/pages/CategoryProduct.test.js",
     "<rootDir>/client/src/pages/ProductDetails.test.js",
@@ -38,7 +39,7 @@ module.exports = {
   // jest code coverage
   collectCoverage: true,
   collectCoverageFrom: [
-    "<rootDir>/client/src/pages/Auth/**", 
+    "<rootDir>/client/src/pages/Auth/**",
     "<rootDir>/client/src/context/**",
     "<rootDir>/client/src/pages/HomePage.js",
     "<rootDir>/client/src/pages/Auth/*.test.js",
@@ -56,6 +57,7 @@ module.exports = {
     "<rootDir>/client/src/pages/admin/UpdateProduct.js",
     "<rootDir>/client/src/pages/admin/AdminOrders.js",
     "<rootDir>/client/src/pages/admin/Products.js",
+    "<rootDir>/client/src/components/Routes/Private.js",
   ],
   coverageThreshold: {
     // Temporary lower the coverage thresholds form 100 to 90 to allow for CI to pass
@@ -69,6 +71,6 @@ module.exports = {
   // more detailed output
   verbose: true,
   reporters: ["default"],
-  silent: false,
+  silent: true,
   testLocationInResults: true,
 };


### PR DESCRIPTION
## Summary of test cases added
> ### **Test Generation Techniques used**: Control Flow Testing, Decision Table Testing
### [frontend] client/src/components/Routes/Private.test.js
`PrivateRoute`
✓ renders outlet after successful auth check (12 ms)
✓ keeps spinner when auth API returns ok=false (3 ms)
✓ keeps spinner and skips auth check when token is undefined (1 ms)
✓ fails closed when the auth check throws (2 ms)

### Improvements made
> 🐞 (bug): If the authentication check failed, `auth?.token` is undefined or `auth/user-auth` returns `{ ok: false }`, then the `Spinner` will render re-directing to `/`. It makes more sense to re-direct to the login page. E.g. when the user is not logged in and tries to access `/dashboard/user`, s/he should be re-directed to `/login` instead of `/`.
> 🔧 (fix): `Spinner` will redirect to `/login`, instead of `/`.

> 🔧 (improvement): Error handling when the `auth/user-auth` API call fails. It will `console.error` log the error and redirect the user to the `/login` page via `Spinner`.

> Note: AI was used for some misc. purposes such as generation of stubs, mock data and code review.